### PR TITLE
Resolve changes to NETFILTER API

### DIFF
--- a/common.h
+++ b/common.h
@@ -14,6 +14,7 @@
 #include <linux/netfilter_arp.h>
 #include <linux/time.h>
 #include <linux/inetdevice.h>
+#include <linux/version.h>
 #include <net/arp.h>
 #include <net/udp.h>
 


### PR DESCRIPTION
This PR addresses compatibility issues with the NETFILTER API introduced in kernel version 4.13. The primary change involves updating the nf_register and nf_unregister function calls. Conditional compilation logic has been added to differentiate between kernels before and after version 4.13. 