### PR TITLE
Improve kernel module time handling for compatibility with newer kernels and long-term systems

### DIFF
--- a/common.h
+++ b/common.h
@@ -13,6 +13,7 @@
 #include <linux/netfilter_ipv4.h>
 #include <linux/netfilter_arp.h>
 #include <linux/time.h>
+#include <linux/ktime.h>
 #include <linux/inetdevice.h>
 #include <linux/version.h>
 #include <net/arp.h>

--- a/main.c
+++ b/main.c
@@ -75,7 +75,11 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
     unsigned char* opt;
     u8 dhcp_packet_type;
     u32 lease_time;
-    struct timespec ts;
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,16,0)
+        struct timespec64 ts;
+    #else
+        struct timespec ts;
+    #endif
     struct dhcp_snooping_entry* entry;
     unsigned int status = NF_ACCEPT;
 
@@ -99,7 +103,11 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
                         }
                     }
                     printk(KERN_INFO "kdai: DHCPACK of %pI4\n", &payload->yiaddr);
-                    getnstimeofday(&ts);
+                    #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,16,0)
+                        ktime_get_real_ts64(&ts);
+                    #else
+                        getnstimeofday(&ts);
+                    #endif
                     entry = find_dhcp_snooping_entry(payload->yiaddr);
                     if (entry) {
                         memcpy(entry->mac, payload->chaddr, ETH_ALEN);


### PR DESCRIPTION
This PR addresses a few compatibility issues related to time handling in the kernel module:

1. Fix for getnstimeofday Declaration:
According to Ian Abbott, since kernel version 3.17.x, getnstimeofday is no longer declared by <linux/time.h>. This PR includes <linux/ktime.h>, which pulls in the getnstimeofday declaration from the appropriate header depending on the kernel version—either <linux/time.h> (pre-3.17.x) or <linux/timekeeping.h> (3.17.x and later). This resolves kernel module compilation failures on newer kernels. 

Note: With #include <linux/ktime.h> there is no need to include <linux/timekeeping.h> directly. You may be able to remove #include <linux/time.h> if there is nothing else in need of its use. 

Link to Ian Abbott Stack Overflow Response: https://stackoverflow.com/questions/50349294/getnstimeofday-is-an-implicit-declaration-in-system-call-when-linux-time-h-i

2. Support for timespec64
Since timespec64 was introduced after kernel version 3.15 but before 3.16 conditional compilation directives have also been added to support future use of timespec64, ensuring the kernel module is compatible with long-term systems.