### PR TITLE
Fix: Spinlock Crashes Kernel in dhcp_thread_handler()

### DIFF
--- a/dhcp.c
+++ b/dhcp.c
@@ -88,9 +88,9 @@ int dhcp_thread_handler(void *arg) {
                 printk(KERN_INFO "kdai:  %pI4 released on %ld\n", &entry->ip, ts.tv_sec);
                 list_del(&entry->list);
                 kfree(entry);
-                spin_unlock_irqrestore(&slock, flags);
             }
         }
+        spin_unlock_irqrestore(&slock, flags);
         msleep(1000);
     }
     return 0;


### PR DESCRIPTION
Problem: There was a race condition in the `dhcp_thread_handler()` function due to the spinlock `slock` being released inside the iteration over the `dhcp_snooping_list`. This led to undefined behavior and kernel crashes when the list was modified during iteration.

To fix this issue, the spinlock is now held for the entire duration of the list iteration, ensuring that no other part of the system can modify the list during the traversal. This change prevents potential race conditions by ensuring that the list remains in a consistent state while it's being modified.