### PR TITLE
ARP Access Control List

### DIFF
--- a/.github/workflows/module-is-buildable-check.yml
+++ b/.github/workflows/module-is-buildable-check.yml
@@ -1,0 +1,24 @@
+name: Module Is Buildable Check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the code
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      # Install required dependencies
+      - name: Install Build Essentials
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+      
+      # Compile the code
+      - name: Compile Code
+        run: make

--- a/main.c
+++ b/main.c
@@ -2,6 +2,8 @@
 #include "dhcp.h"
 #include "errno.h"
 
+#include <linux/netfilter_bridge.h>
+
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("M. Sami GURPINAR <sami.gurpinar@gmail.com>");
 MODULE_DESCRIPTION("kdai(Kernel Dynamic ARP Inspection) is a linux kernel module to defend against arp spoofing");
@@ -219,9 +221,9 @@ static int __init kdai_init(void) {
         goto err;
     
     arpho->hook = (nf_hookfn *) arp_hook;       /* hook function */
-    arpho->hooknum = NF_ARP_IN;                 /* received packets */
-    arpho->pf = NFPROTO_ARP;                    /* ARP */
-    arpho->priority = NF_IP_PRI_FIRST;
+    arpho->hooknum = NF_BR_PRE_ROUTING;         /* received packets */
+    arpho->pf = NFPROTO_BRIDGE;                 /* ARP */
+    arpho->priority = NF_BR_PRI_FIRST;
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
         nf_register_net_hook(&init_net, arpho);
     #else
@@ -234,9 +236,9 @@ static int __init kdai_init(void) {
         goto err;
     
     ipho->hook = (nf_hookfn *) ip_hook;         /* hook function */
-    ipho->hooknum = NF_INET_PRE_ROUTING;        /* received packets */
-    ipho->pf = NFPROTO_IPV4;                    /* IP */
-    ipho->priority = NF_IP_PRI_FIRST;
+    ipho->hooknum = NF_BR_PRE_ROUTING;          /* received packets */
+    ipho->pf = NFPROTO_BRIDGE;                  /* IP */
+    ipho->priority = NF_BR_PRI_FIRST;
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
         nf_register_net_hook(&init_net, ipho);
     #else

--- a/main.c
+++ b/main.c
@@ -167,9 +167,11 @@ static int arp_is_valid(struct sk_buff* skb, u16 ar_op, unsigned char* sha,
     memcpy(shaddr, eth->h_source, ETH_ALEN);
     memcpy(dhaddr, eth->h_dest, ETH_ALEN);
 
+    //This is an optional feature that may be uncommented if administrators choose to.
+    //On Cisco devices this optional check known as “ip arp inspection validate src-mac”. 
     if (memcmp(sha, shaddr, ETH_ALEN) != 0) {
-        printk(KERN_ERR "kdai: the sender MAC address %pM in the message body is NOT identical to the source MAC address in the Ethernet header %pM\n", sha, shaddr);
-        return -EHWADDR;
+        //printk(KERN_ERR "kdai: the sender MAC address %pM in the message body is NOT identical to the source MAC address in the Ethernet header %pM\n", sha, shaddr);
+        //return -EHWADDR;
     } 
 
     if (ipv4_is_multicast(sip)) {

--- a/main.c
+++ b/main.c
@@ -64,7 +64,7 @@ static unsigned int arp_hook(void* priv, struct sk_buff* skb, const struct nf_ho
         return NF_DROP;  
     }
 
-    
+
     if(strcmp(dev->name,"enp0s7")==0){
         //printk(KERN_INFO "kdai: Matched ma1\n");
         return NF_ACCEPT;
@@ -109,8 +109,18 @@ static unsigned int arp_hook(void* priv, struct sk_buff* skb, const struct nf_ho
     }  
 
     //The entries were different from expected. If Static ACL is configured do not Check DHCP table.
-    //If an exisitng entry in the ARP table did not match. Check dynamic DHCP Configuraiton
     
+    int static_ACL_Enabled = 0; // Default is false
+    if (static_ACL_Enabled){
+        //Accept packets only that were statically configured
+        //Since the previous check failed drop the packet
+        printk(KERN_INFO "kdai: Implicit Drop was Added since static_ACL was Enabled\n");
+        status = NF_DROP;
+        print_status(status);
+        return status;
+    }
+    
+    //If an exisitng entry in the ARP table did not match. Check dynamic DHCP Configuraiton
 
     // Query the dhcp snooping table
     // Look up the DHCP Snooping Table to check if there is an entry for the claimed

--- a/main.c
+++ b/main.c
@@ -89,10 +89,13 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
     udp = udp_hdr(skb);
     
     if (udp->source == htons(DHCP_SERVER_PORT) || udp->source == htons(DHCP_CLIENT_PORT)) {
+        printk(KERN_INFO "\nkdai: !! Hooked IP PACKET !!");
         payload = (struct dhcp*) ((unsigned char *)udp + sizeof(struct udphdr));
         
         if (dhcp_is_valid(skb) == 0) {
+            printk(KERN_INFO "kdai: Saw a valid DHCPACK\n");
             memcpy(&dhcp_packet_type, &payload->bp_options[2], 1);
+            printk(KERN_INFO "kdai: DHCP packet type: %u\n", dhcp_packet_type);
             
             switch (dhcp_packet_type) {
                 case DHCP_ACK:{
@@ -141,6 +144,7 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
                     break;
                 }
             default:
+                printk(KERN_INFO "kdai: DHCP defaulted to break\n");
                 break;
             }
       


### PR DESCRIPTION
This PR Adds the ARP Access Control List functionality by fixing logical issues in ARP packet validation. If packets cannot be validated by DHCP Snooping or the ARP Table, they are now dropped. This PR also adds an optional feature in DAI which allows users to select whether or not to check ONLY the Static ACL when implementing DAI.